### PR TITLE
Use ISO 8601 timestamp format in JSON to Loggly

### DIFF
--- a/loggly.go
+++ b/loggly.go
@@ -92,7 +92,7 @@ func New(token string, tags ...string) *Client {
 // Send buffers `msg` for async sending.
 func (c *Client) Send(msg Message) error {
 	if _, exists := msg["timestamp"]; !exists {
-		msg["timestamp"] = time.Now().UnixNano() / int64(time.Millisecond)
+		msg["timestamp"] = time.Now().UTC().Format(time.RFC3339)
 	}
 	merge(msg, c.Defaults)
 


### PR DESCRIPTION
The Loggly documentation states that the timestamp field must be in ISO 8601 format for Loggly to recognize it. This way the actual time displayed in Loggly will be based on the value sent. Currently when sending the UNIX time, Loggly will not recognize it and will display the time it received the message instead.

https://www.loggly.com/docs/automated-parsing/#json